### PR TITLE
Add failproof timeout to exit on frozen geolocation check

### DIFF
--- a/web/components/MapContainer.js
+++ b/web/components/MapContainer.js
@@ -27,10 +27,8 @@ const MapContainer = ({ data }) => {
 
   const [geolocationError, setGeolocationError] = useState(false);
   useEffect(() => {
-    setGeolocationChecked(true);
-    if (true) return;
-    if (!isLoaded) return;
-    if (navigator.geolocation) {
+    if (!isLoaded || geolocationChecked) return;
+    if (navigator.geolocation && navigator.geolocation.getCurrentPosition) {
       navigator.geolocation.getCurrentPosition((position) => {
         const pos = {
           lat: position.coords.latitude,
@@ -40,15 +38,24 @@ const MapContainer = ({ data }) => {
         setUserPosition(pos);
       }, (error) => {
         console.log('Error getting position', error);
-        setGeolocationError(true);
+        if (error.code === error.PERMISSION_DENIED) {
+          setGeolocationError(true);
+        }
         setGeolocationChecked(true);
+      }, {
+        timeout: 5000,
       });
+      setTimeout(() => {
+        if (!geolocationChecked) {
+          setGeolocationChecked(true);
+        }
+      }, 5000);
     } else {
       console.log('It was not allowed');
       setGeolocationError(true);
       setGeolocationChecked(true);
     }
-  }, [isLoaded]);
+  }, [isLoaded, geolocationChecked]);
 
   const [centerOnUser, setCenterOnUser] = useState(false);
   const onDistanceResponse = (response, status) => {

--- a/web/components/MapContainer.js
+++ b/web/components/MapContainer.js
@@ -3,8 +3,8 @@ import { useCallback, useEffect, useState } from 'react';
 import MapWithOverlay from './MapWithOverlay';
 
 const defaultCenter = {
-  lat: 40.7101753,
-  lng: -73.9925543,
+  lat: 40.7361753,
+  lng: -73.9865543,
 };
 
 const libraries = ['places'];


### PR DESCRIPTION
For some reason, in Instagram's embedded browser frame, the browser has access to `navigator.geolocation` and `navigator.geolocation.getCurrentPosition`, and knows they're an `object` and `function` respectively, but once it gets to that code it just... freezes, and nothing else happens. 

This adds a `setTimeout` that will work in case the getCurrentPosition `timeout` never properly fires. 

Unfortunately this still means that in the Instagram browser, users will always have to wait 5 seconds. But at least on other browsers, we have the ability to enable the 'You' tag again.